### PR TITLE
refactor: 로그인한 사용자가 본인 정보 조회 기능 추가

### DIFF
--- a/src/main/java/com/dangun/miniproject/controller/MemberController.java
+++ b/src/main/java/com/dangun/miniproject/controller/MemberController.java
@@ -1,10 +1,13 @@
 package com.dangun.miniproject.controller;
 
-import com.dangun.miniproject.dto.GetMemberRequest;
+import com.dangun.miniproject.common.ApiResponse;
+import com.dangun.miniproject.domain.Member;
+import com.dangun.miniproject.dto.GetMemberDto;
 import com.dangun.miniproject.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,22 +17,29 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    // 다른 회원들의 정보 조회 가능
     @GetMapping("/{memberId}")
-    public GetMemberRequest getMember(@PathVariable Long memberId) {
-        try {
-            return memberService.getMember(memberId);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
+    public GetMemberDto getMember(@PathVariable Long memberId) {
+        return memberService.getMember(memberId);
     }
 
+    // 로그인 한 사용자만 자신의 정보만 조회 가능
+    @GetMapping("/my-info")
+    public ResponseEntity<?> getMyInfo(@AuthenticationPrincipal(expression = "member") Member member) {
+        GetMemberDto getMemberDto = memberService.getMyInfo(member.getId());
+
+        // 정상 처리
+        return ApiResponse.ok("MEMBER-S002", getMemberDto, "회원 정보 조회 성공");
+    }
+
+
+    // 회원 정보 수정
     @PutMapping("/{memberId}")
-    public ResponseEntity<GetMemberRequest> updateMember(
+    public ResponseEntity<GetMemberDto> updateMember(
             @PathVariable Long memberId,
-            @RequestBody GetMemberRequest getMemberRequest
+            @RequestBody GetMemberDto getMemberDto
     ) {
-        return memberService.updateMember(getMemberRequest, memberId);
+        return memberService.updateMember(getMemberDto, memberId);
     }
 
 

--- a/src/main/java/com/dangun/miniproject/domain/Member.java
+++ b/src/main/java/com/dangun/miniproject/domain/Member.java
@@ -1,6 +1,6 @@
 package com.dangun.miniproject.domain;
 
-import com.dangun.miniproject.dto.GetMemberRequest;
+import com.dangun.miniproject.dto.GetMemberDto;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,9 +39,8 @@ public class Member {
         this.password = password;
     }
 
-    public void updateMember(GetMemberRequest getMemberRequest) {
+    public void updateMember(GetMemberDto getMemberRequest) {
         this.email = getMemberRequest.getEmail();
-        this.password = getMemberRequest.getPassword();
         this.nickname = getMemberRequest.getNickname();
     }
 

--- a/src/main/java/com/dangun/miniproject/dto/GetAddressDto.java
+++ b/src/main/java/com/dangun/miniproject/dto/GetAddressDto.java
@@ -1,0 +1,29 @@
+package com.dangun.miniproject.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+public class GetAddressDto {
+    @JsonProperty("street")
+    private String street;
+
+    @JsonProperty("detail")
+    private String detail;
+
+    @JsonProperty("zipcode")
+    private String zipcode;
+
+    @Builder
+    public GetAddressDto(String street, String detail, String zipcode) {
+        this.street = street;
+        this.detail = detail;
+        this.zipcode = zipcode;
+    }
+}

--- a/src/main/java/com/dangun/miniproject/dto/GetAddressResponse.java
+++ b/src/main/java/com/dangun/miniproject/dto/GetAddressResponse.java
@@ -4,14 +4,14 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
-public class GetAddressRequest {
+public class GetAddressResponse {
     private Long id;
     private String street;
     private String detail;
     private String zipcode;
 
     @Builder
-    public GetAddressRequest(Long id, String street, String detail, String zipcode) {
+    public GetAddressResponse(Long id, String street, String detail, String zipcode) {
         this.id = id;
         this.street = street;
         this.detail = detail;

--- a/src/main/java/com/dangun/miniproject/dto/GetMemberDto.java
+++ b/src/main/java/com/dangun/miniproject/dto/GetMemberDto.java
@@ -1,25 +1,28 @@
 package com.dangun.miniproject.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @Builder
 @NoArgsConstructor
-public class GetMemberRequest {
-
-    private Long id;
+@ToString
+public class GetMemberDto {
+    @JsonProperty("email")
     private String email;
-    private String password;
+
+    @JsonProperty("nickname")
     private String nickname;
-    private GetAddressRequest address;
+
+    @JsonProperty("address")
+    private GetAddressDto address;
 
     @Builder
-    public GetMemberRequest(Long id, String email, String password, String nickname, GetAddressRequest address) {
-        this.id = id;
+    public GetMemberDto(String email, String nickname, GetAddressDto address) {
         this.email = email;
-        this.password = password;
         this.nickname = nickname;
         this.address = address;
     }

--- a/src/main/java/com/dangun/miniproject/dto/GetMemberResponse.java
+++ b/src/main/java/com/dangun/miniproject/dto/GetMemberResponse.java
@@ -1,0 +1,27 @@
+package com.dangun.miniproject.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+public class GetMemberResponse {
+
+    private Long id;
+    private String email;
+    private String password;
+    private String nickname;
+    private GetAddressResponse address;
+
+    @Builder
+    public GetMemberResponse(Long id, String email, String password, String nickname, GetAddressResponse address) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.address = address;
+    }
+
+}

--- a/src/main/java/com/dangun/miniproject/service/MemberService.java
+++ b/src/main/java/com/dangun/miniproject/service/MemberService.java
@@ -1,13 +1,16 @@
 package com.dangun.miniproject.service;
 
-import com.dangun.miniproject.dto.GetMemberRequest;
+import com.dangun.miniproject.dto.GetMemberDto;
+import com.dangun.miniproject.dto.GetMemberResponse;
 import org.springframework.http.ResponseEntity;
 
 public interface MemberService {
 
-    GetMemberRequest getMember(Long id);
+    GetMemberDto getMember(Long id);
 
-    ResponseEntity<GetMemberRequest> updateMember(GetMemberRequest getMemberRequest, Long id);
+    GetMemberDto getMyInfo(Long id);
+
+    ResponseEntity<GetMemberDto> updateMember(GetMemberDto getMemberDto, Long id);
 
     boolean deleteMember(Long id);
 }

--- a/src/main/java/com/dangun/miniproject/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/dangun/miniproject/service/impl/MemberServiceImpl.java
@@ -2,8 +2,10 @@ package com.dangun.miniproject.service.impl;
 
 import com.dangun.miniproject.domain.Address;
 import com.dangun.miniproject.domain.Member;
-import com.dangun.miniproject.dto.GetAddressRequest;
-import com.dangun.miniproject.dto.GetMemberRequest;
+import com.dangun.miniproject.dto.GetAddressResponse;
+import com.dangun.miniproject.dto.GetAddressDto;
+import com.dangun.miniproject.dto.GetMemberDto;
+import com.dangun.miniproject.dto.GetMemberResponse;
 import com.dangun.miniproject.repository.AddressRepository;
 import com.dangun.miniproject.repository.BoardRepository;
 import com.dangun.miniproject.repository.CommentRepository;
@@ -29,82 +31,72 @@ public class MemberServiceImpl implements MemberService {
     private final CommentRepository commentRepository;
 
     @Override
-    public GetMemberRequest getMember(Long id) {
+    public GetMemberDto getMember(Long id) {
         // Member 엔티티를 조회
         Optional<Member> optionalMember = memberRepository.findById(id);
 
         // MemberDto를 초기화
-        GetMemberRequest.GetMemberRequestBuilder getMemberRequestBuilder = GetMemberRequest.builder();
+        GetMemberDto.GetMemberDtoBuilder getMemberDtoBuilder = GetMemberDto.builder();
 
         optionalMember.ifPresentOrElse(
                 member -> {
                     // Member 엔티티 정보를 기반으로 GetMemberRequest(Dto)를 빌드
-                    getMemberRequestBuilder
-                            .id(member.getId())
+                    getMemberDtoBuilder
                             .email(member.getEmail())
                             .nickname(member.getNickname())
-                            .password(member.getPassword());
+                            .address(getAddressDto(member.getId()));
                 },
                 () -> {
                     System.out.println("Member not found");
                 }
         );
 
-        // Address 정보를 조회
-        Optional<Address> optionalAddress = addressRepository.findById(id);
-
-        optionalAddress.ifPresentOrElse(
-                address -> {
-                    // Address 엔티티 정보를 getAddressRequest(Dto)로 변환
-                    GetAddressRequest getAddressRequest = GetAddressRequest.builder()
-                            .id(address.getId())
-                            .street(address.getStreet())
-                            .detail(address.getDetail())
-                            .zipcode(address.getZipcode())
-                            .build();
-
-                    getMemberRequestBuilder.address(getAddressRequest);
-                },
-                () -> {
-                    System.out.println("Address not found");
-                }
-        );
-
-        return getMemberRequestBuilder.build();
+        return getMemberDtoBuilder.build();
     }
 
     @Override
-    public ResponseEntity<GetMemberRequest> updateMember(GetMemberRequest getMemberRequest, Long id) {
+    public GetMemberDto getMyInfo(Long id) {
+        // Member 엔티티를 조회
+        Member member = memberRepository.findById(id).orElseThrow();
+
+        GetAddressDto getAddressDto = new GetAddressDto(member.getAddress().getStreet(), member.getAddress().getDetail(), member.getAddress().getZipcode());
+
+        GetMemberDto getMemberDto = GetMemberDto.builder()
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .address(getAddressDto).build();
+
+        return getMemberDto;
+    }
+
+    @Override
+    public ResponseEntity<GetMemberDto> updateMember(GetMemberDto getMemberDto, Long id) {
         Optional<Member> optionalMember = memberRepository.findById(id);
 
         if (optionalMember.isPresent()) {
             Member member = optionalMember.get();
-            member.updateMember(getMemberRequest);
+            member.updateMember(getMemberDto);
 
             memberRepository.save(member);
 
-            GetMemberRequest updatedMemberRequest = GetMemberRequest.builder()
-                    .id(member.getId())
+            GetMemberDto updatedMemberDto = GetMemberDto.builder()
                     .email(member.getEmail())
-                    .password(member.getPassword())
                     .nickname(member.getNickname())
-                    .address(getAddressRequest(member.getId()))
                     .build();
 
-            return ResponseEntity.ok(updatedMemberRequest);
+            return ResponseEntity.ok(updatedMemberDto);
         } else {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
     }
 
 
-    private GetAddressRequest getAddressRequest(Long memberId) {
+    private GetAddressDto getAddressDto(Long memberId) {
         // 주소 정보를 반환하는 메소드 (기본 예시)
         Optional<Address> addressOptional = addressRepository.findById(memberId);
         if (addressOptional.isPresent()) {
             Address address = addressOptional.get();
-            return GetAddressRequest.builder()
-                    .id(address.getId())
+            return GetAddressDto.builder()
                     .street(address.getStreet())
                     .detail(address.getDetail())
                     .zipcode(address.getZipcode())

--- a/src/test/java/com/dangun/miniproject/domain/AddressTest.java
+++ b/src/test/java/com/dangun/miniproject/domain/AddressTest.java
@@ -1,0 +1,46 @@
+package com.dangun.miniproject.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class AddressTest {
+    private Address address;
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        member = Member.builder()
+                .email("hong@test.com")
+                .nickname("Hong")
+                .password("password123")
+                .build();
+
+        address = Address.builder()
+                .street("123 주요 거리")
+                .detail("101동 아파트")
+                .zipcode("14352")
+                .member(member) // Member 설정
+                .build();
+    }
+
+    // 주소 객체 생성 테스트
+    @Test
+    public void createAddress() {
+        assertNotNull(address);
+        assertEquals("123 주요 거리", address.getStreet());
+        assertEquals("101동 아파트", address.getDetail());
+        assertEquals("14352", address.getZipcode());
+        assertEquals(member, address.getMember()); // Member 설정 확인
+    }
+
+    // 주소와 멤버 관계 테스트
+    @Test
+    public void addressMemberRelationship() {
+        assertNotNull(address.getMember());
+        assertEquals("hong@test.com", address.getMember().getEmail());
+        assertEquals("Hong", address.getMember().getNickname());
+    }
+}

--- a/src/test/java/com/dangun/miniproject/domain/MemberTest.java
+++ b/src/test/java/com/dangun/miniproject/domain/MemberTest.java
@@ -1,0 +1,88 @@
+package com.dangun.miniproject.domain;
+
+import com.dangun.miniproject.dto.GetMemberDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MemberTest {
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        member = Member.builder()
+                .email("hong@test.com")
+                .nickname("Hong")
+                .password("password123")
+                .build();
+    }
+
+    // 회원 정보 업데이트 테스트
+    @Test
+    public void updateMember() {
+        // Given
+        GetMemberDto updateRequest = GetMemberDto.builder()
+                .email("newemail@test.com")
+                .nickname("NewHong")
+                .build();
+
+        // When
+        member.updateMember(updateRequest);
+
+        // Then
+        assertEquals("newemail@test.com", member.getEmail());
+        assertEquals("NewHong", member.getNickname());
+    }
+
+    // 주소 추가 테스트
+    @Test
+    public void addAddress() {
+        // Given
+        Address address = Address.builder()
+                .street("123 주요 거리")
+                .detail("101동 아파트")
+                .zipcode("14352")
+                .build();
+
+        // When
+        member.addAddress(address);
+
+        // Then
+        assertNotNull(member.getAddress());
+        assertEquals(address.getStreet(), member.getAddress().getStreet());
+        assertEquals(address.getDetail(), member.getAddress().getDetail());
+        assertEquals(address.getZipcode(), member.getAddress().getZipcode());
+    }
+
+    // 비밀번호 확인 테스트
+    @Test
+    public void checkPassword() {
+        // Given
+        String inputPassword = "password123"; // 올바른 비밀번호
+
+        // Then
+        assertEquals(inputPassword, member.getPassword());
+    }
+
+    // 댓글 삭제 테스트
+    @Test
+    public void removeComment() {
+        // Given
+        Board board = new Board(); // Board 객체 생성 (테스트를 위한 빈 객체)
+        Comment comment = Comment.builder()
+                .content("이것은 댓글입니다.")
+                .member(member) // 댓글과 멤버의 관계 설정
+                .board(board) // 댓글과 게시판의 관계 설정
+                .build();
+        member.getComments().add(comment); // 댓글 추가
+
+        // When
+        member.getComments().remove(comment);
+
+        // Then
+        assertEquals(0, member.getComments().size());
+    }
+
+}

--- a/src/test/java/com/dangun/miniproject/repository/AddressRepositoryTest.java
+++ b/src/test/java/com/dangun/miniproject/repository/AddressRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.dangun.miniproject.repository;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AddressRepositoryTest {
+
+    @Mock
+    private AddressRepository addressRepository;
+
+    @BeforeEach
+    public void setUp() {
+        // 초기 설정이 필요하지 않음
+    }
+
+    // 특정 회원 ID로 주소 삭제 테스트
+    @Test
+    public void deleteByMemberId() {
+        // Given
+        Long memberId = 1L;
+
+        // When
+        addressRepository.deleteByMemberId(memberId);
+
+        // Then
+        verify(addressRepository).deleteByMemberId(memberId);
+    }
+}

--- a/src/test/java/com/dangun/miniproject/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/dangun/miniproject/repository/MemberRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.dangun.miniproject.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.dangun.miniproject.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+public class MemberRepositoryTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        member = Member.builder()
+                .email("hong@test.com")
+                .nickname("Hong")
+                .password("password123")
+                .build();
+    }
+
+    // 이메일 존재 여부 확인 테스트
+    @Test
+    public void existsByEmail() {
+        // Given
+        when(memberRepository.existsByEmail("hong@test.com")).thenReturn(true);
+
+        // When
+        Boolean result = memberRepository.existsByEmail("hong@test.com");
+
+        // Then
+        assertTrue(result);
+        verify(memberRepository).existsByEmail("hong@test.com");
+    }
+
+    // 이메일로 회원 조회 테스트
+    @Test
+    public void findByEmail() {
+        // Given
+        when(memberRepository.findByEmail("hong@test.com")).thenReturn(member);
+
+        // When
+        Member result = memberRepository.findByEmail("hong@test.com");
+
+        // Then
+        assertNotNull(result);
+        assertEquals("hong@test.com", result.getEmail());
+        assertEquals("Hong", result.getNickname());
+        verify(memberRepository).findByEmail("hong@test.com");
+    }
+
+    // 닉네임 존재 여부 확인 테스트
+    @Test
+    public void existsByNickname() {
+        // Given
+        when(memberRepository.existsByNickname("Hong")).thenReturn(true);
+
+        // When
+        Boolean result = memberRepository.existsByNickname("Hong");
+
+        // Then
+        assertTrue(result);
+        verify(memberRepository).existsByNickname("Hong");
+    }
+}


### PR DESCRIPTION
개요
---
- 로그인한 사용자가 본인 정보만 조회 가능한 기능 추가
    - 조회 정보는 email, nickname, street, detail, zipcode
- dto
    - 클래스 명 변경: GetMemberRequest → GetMemberResponse
    - 추가: GetAddressDto(id 제외 모든 주소 필드) 추가
    - 추가: GetMemberDto(id, password 제외 모든 회원 필드) 추가
- 각 테스트 계층 통과